### PR TITLE
Change mechanics of how the input word is chosen

### DIFF
--- a/asos.tmux
+++ b/asos.tmux
@@ -16,13 +16,17 @@ get_tmux_option() {
 readonly key="$(get_tmux_option "@asos-key" "C-a")"
 readonly nopfx="$(get_tmux_option "@asos-key-noprefix" '')"
 
-
 tmux bind ${nopfx:+-n} "$key" \
-    capture-pane -b asos_in                                                             \\\; \
-    save-buffer  -b asos_in "${ASOS_TMPDIR:-/tmp}/asos.in"                              \\\; \
-    run-shell    "${CURRENT_DIR}/scripts/comp_asos.sh > ${ASOS_TMPDIR:-/tmp}/asos.out"  \\\; \
-    load-buffer  -b asos_out "${ASOS_TMPDIR:-/tmp}/asos.out"                            \\\; \
-    send-keys    'C-w'                                                                  \\\; \
-    paste-buffer -b asos_out -s ""                                                      \\\; \
+    copy-mode                                                                          \\\; \
+    send-keys -X cursor-left                                                           \\\; \
+    send-keys -X begin-selection                                                       \\\; \
+    send-keys -X previous-word                                                         \\\; \
+    send-keys -X copy-selection                                                        \\\; \
+    send-keys -X cancel                                                                \\\; \
+    save-buffer  "${ASOS_TMPDIR:-/tmp}/asos.in"                                        \\\; \
+    run-shell    "${CURRENT_DIR}/scripts/comp_asos.sh > ${ASOS_TMPDIR:-/tmp}/asos.out" \\\; \
+    load-buffer  -b asos_out "${ASOS_TMPDIR:-/tmp}/asos.out"                           \\\; \
+    send-keys    'C-w'                                                                 \\\; \
+    paste-buffer -b asos_out -s ""                                                     \\\; \
     run-shell    "rm ${ASOS_TMPDIR:-/tmp}/{asos.{in,out,allpanes},compword.out}"
 

--- a/scripts/comp_asos.sh
+++ b/scripts/comp_asos.sh
@@ -2,7 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-readonly compword="${1:-$(awk -v RS='' 'END {print $NF;}' ${ASOS_TMPDIR:-/tmp}/asos.in)}"
+readonly compword="${1:-$(cat ${ASOS_TMPDIR:-/tmp}/asos.in)}"
 
 echo "${compword}" > "${ASOS_TMPDIR:-/tmp}/compword.out"
 


### PR DESCRIPTION
Some terminals, such as Fish, insert text at the end of the line the
user is currently typing on. Because of this, the previous method of
finding the last word input by the user, which assumed it was the last
word of the buffer, was yielding inconsistent results (e.g. completing
the time at the end of the line).

The current approach takes advantage of the fact the cursor stays in its
current position when the tmux enters copy-mode.

Therefore, this approach does the following:

1. Enters copy mode
2. Move the cursor to the left
3. Starts selection
4. Moves to the previous word
5. Copies the selection
6. Cancel copy mode

With this, I was able to reliably complete words, even in Fish, which
has the time at the end of the line.